### PR TITLE
Update Z_safe_home in configs

### DIFF
--- a/VORON2.4_300model.cfg
+++ b/VORON2.4_300model.cfg
@@ -303,7 +303,7 @@ initial_BLUE: 0.2                   		# Blue The default value for switching on 
 timeout: 1800                       		# The hot bed is switched off if the idle time exceeds 30 minutes
 
 [safe_z_home]                       		# Z-axis limit coordinates
-home_xy_position:203,300            	# X, Y coordinates where the Z origin is located (e.g. 100, 100)
+home_xy_position:-10,-10           	 	# X, Y coordinates where the Z origin is located (e.g. 100, 100)
 speed:100                           		# Speed at which the printhead moves to the safe Z home position, default value 50 mm/s
 z_hop:10                            		# Distance in mm to raise the Z-axis before homing, applied to any homing command even if it does not homing the Z-axis
 z_hop_speed: 10                     		# Z-axis lift speed before homing (mm/s) Default is 20 mm/s.

--- a/VORON2.4_350model.cfg
+++ b/VORON2.4_350model.cfg
@@ -318,7 +318,7 @@ initial_BLUE: 0.2                   # 蓝色 灯开机默认值最大是1
 timeout: 1800                       # 空闲时间超过30分钟则关闭热床
 
 [safe_z_home]                       # Z轴限位坐标
-home_xy_position:203,300            # Z原点所在的X、Y坐标（如100，100）， 执行。必须提供此参数。
+home_xy_position:-10,-10            # X, Y coordinates where the Z origin is located (e.g. 100, 100)
 speed:100                           # 喷头移动到安全Z原点的速度，默认值为50 mm/s
 z_hop:10                            # 归位前提升Z轴的距离（mm），应用于任何归位命令，即使它没有使Z轴归位
 z_hop_speed: 10                     # 归位前Z轴提升的速度（mm/s） 默认为20mm/s.


### PR DESCRIPTION
Updating `[safe_z_home]` from `home_xy_position:200,300` to `home_xy_position:-10,-10` for both sizes of v2.4 configs

A default config needs to have it as -10,-10 to FORCE an error if the user does not edit the coordinates to match the exact location of their pin. since it can change user to user, having a predefined location is a bad idea and can cause the printer to miss their pin and crash down, risking breaking parts, bending extrusions and damaging the printer.